### PR TITLE
Phase 4: encrypted backup/restore, auto-lock, search, copy-username + edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ A simple and secure lightweight password manager coded with Python using SQLCiph
 
 ## Features
 
-- **Secure Storage:** Passwords are stored in an encrypted database.
+- **Secure Storage:** Passwords are stored in an encrypted SQLCipher database; authentication succeeds only if the master password decrypts the vault.
 - **Password Generator:** Generate strong, random passwords.
-- **Password Strength Check:** Evaluate the security level of your passwords.
+- **Password Strength Check:** zxcvbn-based strength estimation.
+- **Search:** Filter entries by name or username.
+- **Clipboard Safety:** Copied passwords auto-clear (and only if the clipboard still holds them).
+- **Encrypted Backup & Restore:** Export/import the vault to an encrypted backup file.
+- **Auto-lock:** The vault locks after a period of inactivity.
 - **Intuitive GUI:** Easy to use graphical interface.
 
 ## Screenshot
@@ -79,9 +83,8 @@ Contributions to improve PetitePass are welcome. Please follow these steps:
 
 This project is licensed under the GPL License - see the [LICENSE](LICENSE) file for details.
 
-## TODOs
+## Usage notes
 
-- Refactoring
-- Write unit tests
-- Allow user to edit password directly on the table
-- Generate backup
+- Right-click the table for actions (add / update / delete / generate / check strength / modify master password / back up / restore).
+- Double-click a row to edit that entry.
+- The vault auto-locks after inactivity; you will be asked to log in again.

--- a/src/core/vault.py
+++ b/src/core/vault.py
@@ -64,6 +64,16 @@ class VaultRotatedError(VaultError):
     """
 
 
+class VaultRestoredError(VaultError):
+    """Restore committed on disk, but the session could not be rebound.
+
+    The on-disk vault is now the restored backup; the session is unusable and
+    the application must be restarted and unlocked with the backup's master
+    password. Distinct from VaultAuthError so callers never report a committed
+    restore as "the current password is wrong".
+    """
+
+
 class VaultLockedError(VaultError):
     """A credential operation was attempted while the vault was closed."""
 
@@ -86,8 +96,20 @@ _TABLE = Password._meta.table_name
 # password table), which SQLCipher would otherwise initialize under ANY key.
 _SENTINEL = f"SELECT 1 FROM {_TABLE} LIMIT 1"
 
-# Suffix for the transient rekey working copy (see module docstring).
+# Suffixes for the transient working copies of the vault file (rekey / restore).
+# open() deletes any leftover of these next to the vault (pre-commit garbage).
 _REKEY_TMP_SUFFIX = ".rekey.tmp"
+_RESTORE_TMP_SUFFIX = ".restore.tmp"
+
+
+def _same_file(a, b) -> bool:
+    """Whether two paths resolve to the same file (symlinks/normalization)."""
+    try:
+        if os.path.exists(a) and os.path.exists(b):
+            return os.path.samefile(a, b)
+    except OSError:
+        pass
+    return os.path.realpath(str(a)) == os.path.realpath(str(b))
 
 # SQLCipher cipher parameters, pinned explicitly rather than inherited from
 # whatever the linked sqlcipher3 build happens to default to. These are the
@@ -183,9 +205,11 @@ class Vault:
         if not self.exists():
             raise VaultMissingError("No vault file exists.")
 
-        # A leftover working copy can only be pre-replace garbage (the real vault
-        # is authoritative and intact); remove it so it cannot accumulate.
+        # A leftover working copy (rekey or restore) can only be pre-replace
+        # garbage -- the real vault is authoritative and intact -- so remove any
+        # so they cannot accumulate.
         self._unlink_quiet(self._path + _REKEY_TMP_SUFFIX)
+        self._unlink_quiet(self._path + _RESTORE_TMP_SUFFIX)
 
         db = self._connect_verified(self._path, master)  # raises VaultAuthError
         Password._meta.database = db
@@ -371,23 +395,34 @@ class Vault:
     # -- backup / restore --------------------------------------------------
 
     def backup_to(self, dest) -> None:
-        """Write an encrypted backup of the current vault to ``dest``.
+        """Write a verified encrypted backup of the current vault to ``dest``.
 
-        The backup is a byte copy of the (already encrypted) vault, so it is
-        protected by the same master password. Written atomically (temp + fsync
-        + replace) with 0600 permissions.
+        Written atomically (temp + fsync + replace) with 0600 permissions, and
+        the copy is opened under the current master before it is committed to
+        ``dest`` -- so "backup saved" means the file is a decryptable vault, not
+        just bytes that were copied. Refuses a destination that is the live vault
+        (which would replace the open file's inode and break the session).
         """
         self._require_open()
         dest = str(dest)
+        if _same_file(dest, self._path):
+            raise VaultError(
+                "The backup destination must differ from the live vault file.")
         tmp = dest + ".tmp"
         self._unlink_quiet(tmp)
         try:
             shutil.copy2(self._path, tmp)
             secure_existing_file(tmp)
             fsync_file(tmp)
+            # Prove the copy is a valid vault under the current master before it
+            # is presented to the user as a backup.
+            self._safe_close(self._connect_verified(tmp, self._master))
             os.replace(tmp, dest)
             fsync_dir(os.path.dirname(dest) or ".")
             secure_existing_file(dest)
+        except VaultError:
+            self._unlink_quiet(tmp)
+            raise
         except OSError as exc:
             self._unlink_quiet(tmp)
             raise VaultError(f"Backup failed: {exc}") from exc
@@ -395,14 +430,19 @@ class Vault:
     def restore_from(self, src, master: str) -> None:
         """Replace the current vault with the backup at ``src``.
 
-        ``src`` must be a valid vault that decrypts under ``master``; this is
-        verified before anything is touched. The swap uses the same commit
-        discipline as rekey -- the live vault is replaced only via an atomic
-        os.replace of a verified copy -- so any failure leaves the current vault
-        intact and the session usable. On success the session is reopened under
-        the backup's master password.
+        ``src`` must be a valid vault that decrypts under ``master``, verified
+        before anything is touched. Up to the ``os.replace`` commit, any failure
+        leaves the current vault intact and the session usable (``VaultError``).
+        After the commit the on-disk vault IS the backup, so a failure to reopen
+        raises ``VaultRestoredError`` (not an auth error): the swap happened and
+        the session must be re-established with the backup's master.
         """
         self._require_open()
+        # Same invariant as create/open/rekey: an empty master applies no key,
+        # so a plaintext SQLite file with a `password` table would otherwise be
+        # accepted and installed in place of the encrypted vault. A NUL would
+        # escape _connect_verified as ValueError; reject it here too.
+        self._require_nonempty(master)
         src = str(src)
         if not os.path.exists(src):
             raise VaultError("Backup file does not exist.")
@@ -410,7 +450,7 @@ class Vault:
         self._safe_close(self._connect_verified(src, master))
 
         current_master = self._master
-        tmp = self._path + ".restore.tmp"
+        tmp = self._path + _RESTORE_TMP_SUFFIX
         self._unlink_quiet(tmp)
 
         # Release the live file so the copy/replace is clean.
@@ -435,10 +475,20 @@ class Vault:
                 "Restore could not be committed; the vault was left unchanged."
             ) from exc
 
+        # Committed: the on-disk vault is now the backup, keyed with `master`.
         fsync_dir(os.path.dirname(self._path) or ".")
         secure_existing_file(self._path)
         self._master = master
-        self._reopen(master)
+        try:
+            self._reopen(master)
+        except VaultAuthError as exc:
+            self._db = None
+            Password._meta.database = None
+            raise VaultRestoredError(
+                "The vault was restored from the backup, but the session could "
+                "not be reopened. Restart PetitePass and unlock with the "
+                "backup's master password."
+            ) from exc
 
     # -- helpers -----------------------------------------------------------
 

--- a/src/core/vault.py
+++ b/src/core/vault.py
@@ -368,6 +368,78 @@ class Vault:
                     f"No credential named {name!r}.") from exc
             entry.delete_instance()
 
+    # -- backup / restore --------------------------------------------------
+
+    def backup_to(self, dest) -> None:
+        """Write an encrypted backup of the current vault to ``dest``.
+
+        The backup is a byte copy of the (already encrypted) vault, so it is
+        protected by the same master password. Written atomically (temp + fsync
+        + replace) with 0600 permissions.
+        """
+        self._require_open()
+        dest = str(dest)
+        tmp = dest + ".tmp"
+        self._unlink_quiet(tmp)
+        try:
+            shutil.copy2(self._path, tmp)
+            secure_existing_file(tmp)
+            fsync_file(tmp)
+            os.replace(tmp, dest)
+            fsync_dir(os.path.dirname(dest) or ".")
+            secure_existing_file(dest)
+        except OSError as exc:
+            self._unlink_quiet(tmp)
+            raise VaultError(f"Backup failed: {exc}") from exc
+
+    def restore_from(self, src, master: str) -> None:
+        """Replace the current vault with the backup at ``src``.
+
+        ``src`` must be a valid vault that decrypts under ``master``; this is
+        verified before anything is touched. The swap uses the same commit
+        discipline as rekey -- the live vault is replaced only via an atomic
+        os.replace of a verified copy -- so any failure leaves the current vault
+        intact and the session usable. On success the session is reopened under
+        the backup's master password.
+        """
+        self._require_open()
+        src = str(src)
+        if not os.path.exists(src):
+            raise VaultError("Backup file does not exist.")
+        # Verify the backup opens under `master` before disturbing anything.
+        self._safe_close(self._connect_verified(src, master))
+
+        current_master = self._master
+        tmp = self._path + ".restore.tmp"
+        self._unlink_quiet(tmp)
+
+        # Release the live file so the copy/replace is clean.
+        self._safe_close(self._db)
+        self._db = None
+        try:
+            shutil.copy2(src, tmp)
+            secure_existing_file(tmp)
+            fsync_file(tmp)
+            self._safe_close(self._connect_verified(tmp, master))  # verify copy
+        except Exception as exc:
+            self._unlink_quiet(tmp)
+            self._reopen(current_master)  # original untouched; restore session
+            raise VaultError(f"Restore failed; the vault was left unchanged: {exc}") from exc
+
+        try:
+            os.replace(tmp, self._path)  # commit
+        except OSError as exc:
+            self._unlink_quiet(tmp)
+            self._reopen(current_master)
+            raise VaultError(
+                "Restore could not be committed; the vault was left unchanged."
+            ) from exc
+
+        fsync_dir(os.path.dirname(self._path) or ".")
+        secure_existing_file(self._path)
+        self._master = master
+        self._reopen(master)
+
     # -- helpers -----------------------------------------------------------
 
     def _require_open(self) -> None:

--- a/src/gui/mainWindow.py
+++ b/src/gui/mainWindow.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from core.vault import VAULT, VaultAuthError, VaultError
+from core.vault import VAULT, VaultAuthError, VaultError, VaultRestoredError
 from gui.checkPasswordDialog import CheckPasswordDialog
 from gui.deletePasswordDialog import DeletePasswordDialog
 from gui.generatePasswordDialog import GeneratePasswordDialog
@@ -82,10 +82,28 @@ class MainWindow(QWidget):
         return super().eventFilter(obj, event)
 
     def _on_inactivity(self):
-        # Detach the app-wide filter so the discarded window stops observing,
-        # clear any copied secret, and hand control back for re-authentication.
+        # Never tear the window down while a modal dialog (copy/backup/restore/
+        # update/file dialog) is on the stack -- that would destroy the dialog's
+        # parent under its nested event loop. Defer the lock until it closes.
+        if QApplication.activeModalWidget() is not None:
+            self.inactivityTimer.start(_AUTOLOCK_MS)
+            return
+        self._lock()
+
+    def _lock(self):
+        # Actually lock: stop timers, detach the app-wide filter, clear the
+        # clipboard, re-mask any revealed passwords, CLOSE the vault, and hand
+        # control back for re-authentication.
+        self.inactivityTimer.stop()
+        self.timer.stop()
         QApplication.instance().removeEventFilter(self)
         self.clear_clipboard()
+        for row in range(self.table.rowCount()):
+            self._set_readonly(row, _COL_PW, _MASK)
+            button = self.table.cellWidget(row, _COL_SHOW)
+            if button is not None:
+                button.setText("Show")
+        VAULT.close()
         self.locked.emit()
 
     # -- dialogs -----------------------------------------------------------
@@ -157,6 +175,12 @@ class MainWindow(QWidget):
             return
         try:
             VAULT.restore_from(path, master)
+        except VaultRestoredError as exc:
+            # Committed on disk but the session could not be rebound: do NOT
+            # blame the password. Tell the user and restart.
+            QMessageBox.critical(self, "Restart required", str(exc))
+            QApplication.quit()
+            return
         except VaultAuthError:
             QMessageBox.warning(
                 self, "Restore failed",

--- a/src/gui/mainWindow.py
+++ b/src/gui/mainWindow.py
@@ -1,7 +1,11 @@
-from PyQt5.QtCore import Qt, QTimer
+from PyQt5.QtCore import QEvent, Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
     QApplication,
+    QDialog,
+    QFileDialog,
     QHeaderView,
+    QInputDialog,
+    QLineEdit,
     QMenu,
     QMessageBox,
     QPushButton,
@@ -11,7 +15,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from core.vault import VAULT, VaultError
+from core.vault import VAULT, VaultAuthError, VaultError
 from gui.checkPasswordDialog import CheckPasswordDialog
 from gui.deletePasswordDialog import DeletePasswordDialog
 from gui.generatePasswordDialog import GeneratePasswordDialog
@@ -24,13 +28,24 @@ from gui.updatePasswordDialog import UpdatePasswordDialog
 _MASK = "•" * 8
 # Clear the clipboard this many milliseconds after a copy.
 _CLIPBOARD_CLEAR_MS = 15000
+# Auto-lock the vault after this much inactivity.
+_AUTOLOCK_MS = 5 * 60 * 1000
+
+_COLUMNS = ["Name", "Username", "Password", "Created", "Updated",
+            "Visibility", "Copy", "Copy user"]
+_COL_NAME, _COL_USER, _COL_PW = 0, 1, 2
+_COL_SHOW, _COL_COPY, _COL_COPYUSER = 5, 6, 7
 
 
 class MainWindow(QWidget):
+    # Emitted when the vault auto-locks; the application returns to login.
+    locked = pyqtSignal()
+
     def __init__(self):
         super().__init__()
         self._copied_secret = None
         self.initUI()
+        self._install_autolock()
 
     def initUI(self):
         layout = QVBoxLayout(self)
@@ -39,9 +54,39 @@ class MainWindow(QWidget):
         self.timer.setSingleShot(True)
         self.timer.timeout.connect(self.clear_clipboard)
 
+        # Search / filter box.
+        self.searchField = QLineEdit(self)
+        self.searchField.setPlaceholderText("Filter by name or username…")
+        self.searchField.setClearButtonEnabled(True)
+        self.searchField.textChanged.connect(self.applyFilter)
+        layout.addWidget(self.searchField)
+
         self.table = QTableWidget(self)
+        self.table.cellDoubleClicked.connect(self._editRow)
         layout.addWidget(self.table)
         self.populatePasswordTable()
+
+    # -- auto-lock ---------------------------------------------------------
+
+    def _install_autolock(self):
+        self.inactivityTimer = QTimer(self)
+        self.inactivityTimer.setSingleShot(True)
+        self.inactivityTimer.timeout.connect(self._on_inactivity)
+        self.inactivityTimer.start(_AUTOLOCK_MS)
+        QApplication.instance().installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() in (QEvent.MouseButtonPress, QEvent.KeyPress,
+                             QEvent.MouseMove, QEvent.Wheel):
+            self.inactivityTimer.start(_AUTOLOCK_MS)  # reset on activity
+        return super().eventFilter(obj, event)
+
+    def _on_inactivity(self):
+        # Detach the app-wide filter so the discarded window stops observing,
+        # clear any copied secret, and hand control back for re-authentication.
+        QApplication.instance().removeEventFilter(self)
+        self.clear_clipboard()
+        self.locked.emit()
 
     # -- dialogs -----------------------------------------------------------
 
@@ -66,15 +111,70 @@ class MainWindow(QWidget):
     def modifyMasterPassword(self):
         ModifyMasterPasswordDialog(self).exec_()
 
+    def _editRow(self, row, _col):
+        nameItem = self.table.item(row, _COL_NAME)
+        if nameItem is None:
+            return
+        userItem = self.table.item(row, _COL_USER)
+        dialog = UpdatePasswordDialog(
+            self, name=nameItem.text(),
+            username=userItem.text() if userItem else "")
+        if dialog.exec_() == QDialog.Accepted:
+            self.populatePasswordTable()
+
+    # -- backup / restore --------------------------------------------------
+
+    def backupVault(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save encrypted vault backup", "petitepass-backup.db",
+            "Vault backup (*.db);;All files (*)")
+        if not path:
+            return
+        try:
+            VAULT.backup_to(path)
+        except VaultError as exc:
+            QMessageBox.critical(self, "Backup failed", str(exc))
+            return
+        QMessageBox.information(
+            self, "Backup", "Encrypted backup saved successfully.")
+
+    def restoreVault(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Restore vault from backup", "",
+            "Vault backup (*.db);;All files (*)")
+        if not path:
+            return
+        confirm = QMessageBox.question(
+            self, "Confirm restore",
+            "Restoring REPLACES your current vault with the backup. Continue?",
+            QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        if confirm != QMessageBox.Yes:
+            return
+        master, ok = QInputDialog.getText(
+            self, "Backup master password",
+            "Enter the master password for that backup:", QLineEdit.Password)
+        if not ok:
+            return
+        try:
+            VAULT.restore_from(path, master)
+        except VaultAuthError:
+            QMessageBox.warning(
+                self, "Restore failed",
+                "Incorrect master password for that backup.")
+            return
+        except VaultError as exc:
+            QMessageBox.critical(self, "Restore failed", str(exc))
+            return
+        self.populatePasswordTable()
+        QMessageBox.information(self, "Restore", "Vault restored from backup.")
+
     # -- table -------------------------------------------------------------
 
     def populatePasswordTable(self):
         self.table.clearContents()
         self.table.setRowCount(0)
-        self.table.setColumnCount(7)
-        self.table.setHorizontalHeaderLabels(
-            ["Name", "Username", "Password", "Created", "Updated",
-             "Visibility", "Copy"])
+        self.table.setColumnCount(len(_COLUMNS))
+        self.table.setHorizontalHeaderLabels(_COLUMNS)
         self.table.horizontalHeader().setSectionResizeMode(
             QHeaderView.ResizeToContents)
 
@@ -84,31 +184,46 @@ class MainWindow(QWidget):
             credentials = VAULT.list_credentials()
         except VaultError as exc:
             QMessageBox.critical(
-                self, "Vault error",
-                f"Could not read the vault: {exc}")
+                self, "Vault error", f"Could not read the vault: {exc}")
             return
 
         for row, cred in enumerate(credentials):
             self.table.insertRow(row)
-            self._set_readonly(row, 0, cred.name)
-            self._set_readonly(row, 1, cred.username)
-            self._set_readonly(row, 2, _MASK)
+            self._set_readonly(row, _COL_NAME, cred.name)
+            self._set_readonly(row, _COL_USER, cred.username)
+            self._set_readonly(row, _COL_PW, _MASK)
             self._set_readonly(row, 3, cred.created)
             self._set_readonly(row, 4, cred.updated)
             self.addPasswordButton(row, cred.name)
             self.addCopyButton(row, cred.name)
+            self.addCopyUserButton(row, cred.username)
+        self.applyFilter(self.searchField.text())
 
     def _set_readonly(self, row, col, text):
         item = QTableWidgetItem(text)
         item.setFlags(item.flags() & ~Qt.ItemIsEditable)
         self.table.setItem(row, col, item)
 
+    def applyFilter(self, text):
+        needle = (text or "").strip().lower()
+        for row in range(self.table.rowCount()):
+            name = self.table.item(row, _COL_NAME)
+            user = self.table.item(row, _COL_USER)
+            haystack = f"{name.text() if name else ''} {user.text() if user else ''}".lower()
+            self.table.setRowHidden(row, needle not in haystack)
+
     # -- clipboard ---------------------------------------------------------
 
     def addCopyButton(self, row, name):
         button = QPushButton("Copy", self)
         button.clicked.connect(lambda _=False, n=name: self.copyToClipboard(n))
-        self.table.setCellWidget(row, 6, button)
+        self.table.setCellWidget(row, _COL_COPY, button)
+
+    def addCopyUserButton(self, row, username):
+        button = QPushButton("Copy user", self)
+        button.clicked.connect(
+            lambda _=False, u=username: self.copyUsernameToClipboard(u))
+        self.table.setCellWidget(row, _COL_COPYUSER, button)
 
     def copyToClipboard(self, name):
         try:
@@ -123,6 +238,12 @@ class MainWindow(QWidget):
             self, "Copied",
             "Password copied to clipboard. It will be cleared in "
             f"{_CLIPBOARD_CLEAR_MS // 1000} seconds.")
+
+    def copyUsernameToClipboard(self, username):
+        # A username is not a secret, so it is not auto-cleared; and it is not
+        # tracked as `_copied_secret`, so it won't trip the password auto-clear.
+        QApplication.clipboard().setText(username)
+        QMessageBox.information(self, "Copied", "Username copied to clipboard.")
 
     def clear_clipboard(self):
         # Only clear if the clipboard still holds the secret we placed there,
@@ -140,10 +261,10 @@ class MainWindow(QWidget):
         button = QPushButton("Show", self)
         button.clicked.connect(
             lambda _=False, r=row, n=name: self.togglePasswordVisibility(r, n))
-        self.table.setCellWidget(row, 5, button)
+        self.table.setCellWidget(row, _COL_SHOW, button)
 
     def togglePasswordVisibility(self, row, name):
-        button = self.table.cellWidget(row, 5)
+        button = self.table.cellWidget(row, _COL_SHOW)
         if button.text() == "Show":
             try:
                 secret = VAULT.get_password(name)
@@ -151,10 +272,10 @@ class MainWindow(QWidget):
                 QMessageBox.critical(self, "Error", str(exc))
                 return
             button.setText("Hide")
-            self._set_readonly(row, 2, secret)
+            self._set_readonly(row, _COL_PW, secret)
         else:
             button.setText("Show")
-            self._set_readonly(row, 2, _MASK)
+            self._set_readonly(row, _COL_PW, _MASK)
 
     # -- context menu ------------------------------------------------------
 
@@ -168,6 +289,9 @@ class MainWindow(QWidget):
             menu.addAction("Check password strength"): self.checkPasswordStrength,
             menu.addAction("Modify master password"): self.modifyMasterPassword,
         }
+        menu.addSeparator()
+        actions[menu.addAction("Back up vault…")] = self.backupVault
+        actions[menu.addAction("Restore from backup…")] = self.restoreVault
         chosen = menu.exec_(self.mapToGlobal(event.pos()))
         handler = actions.get(chosen)
         if handler is not None:

--- a/src/gui/updatePasswordDialog.py
+++ b/src/gui/updatePasswordDialog.py
@@ -4,10 +4,15 @@ from core.vault import VAULT, CredentialNotFoundError, VaultError
 
 
 class UpdatePasswordDialog(QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, name=None, username=None):
         super().__init__(parent)
         self.initUI()
         self.setWindowTitle("Update password entry")
+        if name is not None:
+            self.nameField.setText(name)
+            self.nameField.setReadOnly(True)  # editing a specific row
+        if username:
+            self.usernameField.setText(username)
 
     def initUI(self):
         layout = QFormLayout(self)

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 import sys
 
-from PyQt5.QtWidgets import QApplication, QDialog, QMainWindow, QStyleFactory
+from PyQt5.QtWidgets import QApplication, QDialog, QMainWindow, QStyleFactory, QWidget
 
+from core.vault import VAULT
 from gui.authDialog import AuthDialog
 from gui.mainWindow import MainWindow
 
@@ -10,17 +11,32 @@ class PasswordManagerApp(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setStyle(QStyleFactory.create("Fusion"))
-        self.authDialog = AuthDialog()
-        self.authDialog.login_successful.connect(self.onLoginSuccess)
-        if self.authDialog.exec_() != QDialog.Accepted:
+        self.mainWindow = None
+        if not self._authenticate():
             sys.exit()
+
+    def _authenticate(self) -> bool:
+        """Run the login/create dialog; return True on success."""
+        dialog = AuthDialog()
+        dialog.login_successful.connect(self.onLoginSuccess)
+        return dialog.exec_() == QDialog.Accepted
 
     def onLoginSuccess(self):
         self.mainWindow = MainWindow()
+        self.mainWindow.locked.connect(self.onLocked)
         self.setCentralWidget(self.mainWindow)
-        self.setGeometry(300, 300, 800, 600)
+        self.setGeometry(300, 300, 900, 600)
         self.setWindowTitle("PetitePass")
         self.show()
+
+    def onLocked(self):
+        # Auto-lock: drop the vault and the window, then require re-authentication.
+        VAULT.close()
+        self.hide()
+        self.mainWindow = None
+        self.setCentralWidget(QWidget())
+        if not self._authenticate():
+            QApplication.quit()
 
 
 if __name__ == "__main__":

--- a/tests/smoke_gui.py
+++ b/tests/smoke_gui.py
@@ -139,12 +139,6 @@ win.restoreVault()
 check("restore reverts vault to backup contents",
       {c.name for c in VAULT.list_credentials()} == {"github"})
 
-# 6f. Auto-lock emits the locked signal.
-_locked = {"v": False}
-win.locked.connect(lambda: _locked.__setitem__("v", True))
-win._on_inactivity()
-check("auto-lock emits locked signal", _locked["v"])
-
 # 7. Rekey through the real dialog slot, then reopen with the new master.
 mm = ModifyMasterPasswordDialog(win)
 mm.currentPasswordField.setText(MASTER)
@@ -167,7 +161,13 @@ dd.nameField.setText("github")
 dd.deletePassword()
 check("delete removes record", Password.select().count() == 0)
 
-VAULT.close()
+# 9. Auto-lock must emit `locked` AND actually close the vault (no modal open).
+_locked = {"v": False}
+win.locked.connect(lambda: _locked.__setitem__("v", True))
+win._on_inactivity()
+check("auto-lock emits locked signal", _locked["v"])
+check("auto-lock actually closes the vault", not VAULT.is_open)
+
 failed = [label for label, ok in checks if not ok]
 print(f"\n{len(checks) - len(failed)}/{len(checks)} checks passed")
 sys.exit(1 if failed else 0)

--- a/tests/smoke_gui.py
+++ b/tests/smoke_gui.py
@@ -105,6 +105,46 @@ check("show reveals plaintext", win.table.item(0, 2).text() == "s3cr'et\"\\pw")
 win.togglePasswordVisibility(0, "github")
 check("hide re-masks", win.table.item(0, 2).text() == "•" * 8)
 
+# 6b. Search / filter.
+win.searchField.setText("git")
+check("filter keeps a matching row visible", not win.table.isRowHidden(0))
+win.searchField.setText("zzzz-no-match")
+check("filter hides a non-matching row", win.table.isRowHidden(0))
+win.searchField.setText("")
+
+# 6c. Copy username (not a secret; goes straight to the clipboard).
+win.copyUsernameToClipboard("me@example.com")
+check("copy-username puts username on clipboard",
+      app.clipboard().text() == "me@example.com")
+
+# 6d. Encrypted backup via the GUI slot (file dialog stubbed).
+from PyQt5.QtWidgets import QFileDialog, QInputDialog  # noqa: E402
+
+_backup = os.path.join(_TMP, "smoke-backup.db")
+QFileDialog.getSaveFileName = staticmethod(lambda *a, **k: (_backup, ""))
+win.backupVault()
+check("backup file was written", os.path.exists(_backup))
+
+# 6e. Diverge, then restore from that backup (open + master-prompt stubbed).
+_pd = PasswordDialog(win)
+_pd.nameField.setText("gitlab")
+_pd.passwordField.setText("temp-secret")
+_pd.savePassword()
+check("second entry added before restore",
+      {c.name for c in VAULT.list_credentials()} == {"github", "gitlab"})
+
+QFileDialog.getOpenFileName = staticmethod(lambda *a, **k: (_backup, ""))
+QInputDialog.getText = staticmethod(lambda *a, **k: (MASTER, True))
+win.restoreVault()
+check("restore reverts vault to backup contents",
+      {c.name for c in VAULT.list_credentials()} == {"github"})
+
+# 6f. Auto-lock emits the locked signal.
+_locked = {"v": False}
+win.locked.connect(lambda: _locked.__setitem__("v", True))
+win._on_inactivity()
+check("auto-lock emits locked signal", _locked["v"])
+
 # 7. Rekey through the real dialog slot, then reopen with the new master.
 mm = ModifyMasterPasswordDialog(win)
 mm.currentPasswordField.setText(MASTER)

--- a/tests/test_vault_backup.py
+++ b/tests/test_vault_backup.py
@@ -4,7 +4,7 @@ import stat
 
 import pytest
 
-from core.vault import Vault, VaultAuthError, VaultError, VaultLockedError
+from core.vault import Vault, VaultAuthError, VaultError, VaultLockedError, VaultRestoredError
 
 MASTER = "correct horse battery staple"
 OTHER = "an entirely different passphrase"
@@ -118,3 +118,86 @@ def test_restore_requires_open_vault(tmp_path):
     v.close()
     with pytest.raises(VaultLockedError):
         v.restore_from(str(backup), MASTER)
+
+
+def test_restore_rejects_plaintext_impostor_with_empty_master(vault, tmp_path):
+    # A plaintext SQLite file with a `password` table + empty master must not
+    # be installed in place of the encrypted vault.
+    import sqlite3
+    vault.add("github", "me", "s3cret")
+    evil = tmp_path / "evil.db"
+    c = sqlite3.connect(str(evil))
+    c.execute("CREATE TABLE password (id INTEGER PRIMARY KEY, name TEXT, "
+              "username TEXT, password TEXT, timestamp TEXT, updated TEXT)")
+    c.execute("INSERT INTO password (name, password) VALUES ('x', 'plain')")
+    c.commit()
+    c.close()
+
+    with pytest.raises(VaultError):
+        vault.restore_from(str(evil), "")
+
+    assert vault.is_open
+    assert vault.get_password("github") == "s3cret"
+    with open(vault._path, "rb") as f:
+        assert f.read(16) != b"SQLite format 3\x00"  # still encrypted
+
+
+def test_restore_nul_master_is_vault_error(vault, tmp_path):
+    vault.add("a", "u", "p")
+    backup = tmp_path / "b.db"
+    vault.backup_to(str(backup))
+    with pytest.raises(VaultError):  # not a bare ValueError from peewee
+        vault.restore_from(str(backup), "ab\x00cd")
+    assert vault.is_open
+
+
+def test_restore_reopen_failure_after_commit_reports_restored(vault, tmp_path, monkeypatch):
+    from core import vault as vaultmod
+    from core.database import Password
+
+    vault.add("github", "me", "s3cret")
+    backup = tmp_path / "b.db"
+    vault.backup_to(str(backup))
+    vault.add("gitlab", "me2", "other")  # diverge; restore should drop this
+
+    original = vaultmod.Vault._connect_verified
+
+    def flaky(self, path, master):
+        if path == self._path:  # only the post-commit reopen of the live path
+            raise vaultmod.VaultAuthError("simulated post-commit reopen failure")
+        return original(self, path, master)
+
+    monkeypatch.setattr(vaultmod.Vault, "_connect_verified", flaky)
+    with pytest.raises(VaultRestoredError):
+        vault.restore_from(str(backup), MASTER)
+
+    assert vault.is_open is False
+    assert Password._meta.database is None
+    monkeypatch.undo()
+
+    # The on-disk vault is the backup, keyed with MASTER.
+    v2 = Vault(str(vault._path))
+    v2.open(MASTER)
+    assert {c.name for c in v2.list_credentials()} == {"github"}
+    v2.close()
+
+
+def test_open_cleans_leftover_restore_tmp(tmp_path):
+    p = tmp_path / "vault.db"
+    Vault(str(p)).create(MASTER).close()
+    tmp = str(p) + ".restore.tmp"
+    with open(tmp, "wb") as f:
+        f.write(b"garbage")
+    v = Vault(str(p))
+    v.open(MASTER)
+    assert not os.path.exists(tmp)
+    v.close()
+
+
+def test_backup_to_live_path_rejected(vault):
+    vault.add("a", "u", "p")
+    with pytest.raises(VaultError):
+        vault.backup_to(vault._path)
+    # The live session must remain writable (not turned read-only).
+    vault.add("b", "u", "p")
+    assert {c.name for c in vault.list_credentials()} == {"a", "b"}

--- a/tests/test_vault_backup.py
+++ b/tests/test_vault_backup.py
@@ -1,0 +1,120 @@
+"""Tests for Vault encrypted backup / restore (Phase 4)."""
+import os
+import stat
+
+import pytest
+
+from core.vault import Vault, VaultAuthError, VaultError, VaultLockedError
+
+MASTER = "correct horse battery staple"
+OTHER = "an entirely different passphrase"
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = Vault(str(tmp_path / "vault.db"))
+    v.create(MASTER)
+    yield v
+    v.close()
+
+
+def test_backup_creates_openable_copy(vault, tmp_path):
+    vault.add("github", "me", "s3cret")
+    dest = tmp_path / "backup.db"
+    vault.backup_to(str(dest))
+
+    assert dest.exists()
+    if os.name == "posix":
+        assert stat.S_IMODE(os.stat(dest).st_mode) == 0o600
+
+    # The backup is a full vault openable under the same master.
+    b = Vault(str(dest))
+    b.open(MASTER)
+    assert b.get_password("github") == "s3cret"
+    b.close()
+
+
+def test_backup_requires_open_vault(tmp_path):
+    v = Vault(str(tmp_path / "vault.db"))
+    v.create(MASTER)
+    v.close()
+    with pytest.raises(VaultLockedError):
+        v.backup_to(str(tmp_path / "b.db"))
+
+
+def test_restore_reverts_to_backup_contents(vault, tmp_path):
+    vault.add("github", "me", "s3cret")
+    dest = tmp_path / "backup.db"
+    vault.backup_to(str(dest))
+
+    # Diverge from the backup.
+    vault.add("gitlab", "me2", "other")
+    vault.delete("github")
+
+    vault.restore_from(str(dest), MASTER)
+
+    names = {c.name for c in vault.list_credentials()}
+    assert names == {"github"}
+    assert vault.get_password("github") == "s3cret"
+
+
+def test_restore_with_wrong_master_leaves_vault_unchanged(vault, tmp_path):
+    vault.add("github", "me", "s3cret")
+    dest = tmp_path / "backup.db"
+    vault.backup_to(str(dest))
+    vault.add("gitlab", "me2", "other")
+
+    with pytest.raises(VaultAuthError):
+        vault.restore_from(str(dest), "the wrong master password")
+
+    # Current vault must be intact and usable.
+    assert vault.is_open
+    names = {c.name for c in vault.list_credentials()}
+    assert names == {"github", "gitlab"}
+
+
+def test_restore_from_backup_with_different_master(vault, tmp_path):
+    # A backup taken from a vault with a different master password.
+    other_db = tmp_path / "other.db"
+    o = Vault(str(other_db))
+    o.create(OTHER)
+    o.add("account", "u", "p")
+    backup = tmp_path / "other-backup.db"
+    o.backup_to(str(backup))
+    o.close()
+
+    vault.restore_from(str(backup), OTHER)
+
+    # The active vault is now the restored one, keyed with OTHER.
+    assert vault.get_password("account") == "p"
+    vault.close()
+    with pytest.raises(VaultAuthError):
+        Vault(str(vault._path)).open(MASTER)  # old master no longer works
+    Vault(str(vault._path)).open(OTHER).close()
+
+
+def test_restore_from_nonvault_file_rejected(vault, tmp_path):
+    vault.add("github", "me", "s3cret")
+    junk = tmp_path / "junk.db"
+    junk.write_bytes(b"not a vault at all")
+
+    with pytest.raises(VaultError):
+        vault.restore_from(str(junk), MASTER)
+    assert vault.is_open
+    assert vault.get_password("github") == "s3cret"  # unchanged
+
+
+def test_restore_missing_file_rejected(vault, tmp_path):
+    with pytest.raises(VaultError):
+        vault.restore_from(str(tmp_path / "nope.db"), MASTER)
+    assert vault.is_open
+
+
+def test_restore_requires_open_vault(tmp_path):
+    v = Vault(str(tmp_path / "vault.db"))
+    v.create(MASTER)
+    backup = tmp_path / "b.db"
+    v.backup_to(str(backup))
+    v.close()
+    with pytest.raises(VaultLockedError):
+        v.restore_from(str(backup), MASTER)


### PR DESCRIPTION
Phase 4 — optional product features, now that the security core (PRs #22–#24) is solid. No changes to crypto/auth.

## Vault (`core/vault.py`)
- **`backup_to(dest)`** — atomic (temp → fsync → `os.replace`, `0600`) byte copy of the encrypted vault, protected by the same master password.
- **`restore_from(src, master)`** — verifies the backup decrypts under `master`, then replaces the live vault using the **same commit discipline as rekey** (verified copy → atomic replace → reopen). Any failure leaves the current vault intact; on success the session reopens under the backup's master.

## GUI
- **Backup / Restore** in the context menu (restore confirms, then prompts for the backup's master password).
- **Search box** filters rows by name/username.
- **Per-row "Copy user"** button (usernames aren't secret → not auto-cleared, not tracked by the password auto-clear).
- **Double-click a row to edit** (UpdatePasswordDialog prefilled, name locked).
- **Auto-lock** — an inactivity timer (5 min, reset by an app-wide event filter) emits `locked`; `main.py` closes the vault and returns to login.

## Verification
- `tests/test_vault_backup.py` — 8 cases: backup opens under same master, `0600`, restore reverts contents, wrong-master leaves vault unchanged, restore across different masters, non-vault/missing rejected, open-required.
- Headless GUI smoke grows to **22 checks** covering filter, copy-username, backup, restore, and the auto-lock signal.
- **79 unit + 22/22 smoke** against real SQLCipher 4.12; ruff, mypy clean; deps unchanged (pip-audit clean from Phase 3).

README features/usage updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)