### PR TITLE
fix(ci): tag-only release (main is branch-protected)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,21 @@ jobs:
           set -euo pipefail
           init="src/petitepass/__init__.py"
 
-          read_version() {
+          read_file_version() {
             python -c "import re,sys; print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', open('$init').read()).group(1))"
           }
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            cur="$(read_version)"
-            IFS='.' read -r major minor patch <<< "$cur"
+            git fetch --tags --force
+            # Base the bump on the highest existing v*.*.* tag, falling back to
+            # the version declared in __init__.py when there are no tags yet.
+            latest=""
+            while IFS= read -r t; do
+              if [[ "$t" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then latest="$t"; break; fi
+            done < <(git tag -l 'v*' --sort=-v:refname)
+            if [ -n "$latest" ]; then base="${latest#v}"; else base="$(read_file_version)"; fi
+
+            IFS='.' read -r major minor patch <<< "$base"
             case "${INPUT_BUMP:-patch}" in
               major) major=$((major + 1)); minor=0; patch=0 ;;
               minor) minor=$((minor + 1)); patch=0 ;;
@@ -101,38 +109,24 @@ jobs:
             esac
             version="${major}.${minor}.${patch}"
             tag="v${version}"
-            echo "Bump ${INPUT_BUMP:-patch}: ${cur} -> ${version}"
+            echo "Base ${base}, bump ${INPUT_BUMP:-patch} -> ${version}"
 
             if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
               echo "tag ${tag} already exists" >&2; exit 1
             fi
 
-            # Write the new version, commit, and tag so the tagged tree matches.
-            python - "$init" "$version" <<'PY'
-          import re, sys
-          path, version = sys.argv[1], sys.argv[2]
-          text = open(path).read()
-          text = re.sub(r'__version__\s*=\s*"[^"]+"', f'__version__ = "{version}"', text)
-          open(path, "w").write(text)
-          PY
+            # Tag ONLY. main is protected (changes must go through a PR), so the
+            # release must not push a commit to it. The binary is version-stamped
+            # from this tag at build time; the tag pushed with GITHUB_TOKEN does
+            # not start another workflow run, so no recursion into the tag trigger.
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add "$init"
-            git commit -m "chore(release): ${tag}"
             git tag -a "$tag" -m "$tag"
-            # A push with GITHUB_TOKEN does not start another workflow run, so
-            # the tag push below cannot recurse into the push trigger.
-            git push origin "HEAD:${GITHUB_REF_NAME}"
             git push origin "$tag"
           else
-            # Tag push: the tag is the source of truth; verify it matches the file.
+            # Tag push: the tag is the source of truth.
             tag="$REF_NAME"
             version="${tag#v}"
-            file_version="$(read_version)"
-            if [ "$version" != "$file_version" ]; then
-              echo "tag ${tag} does not match __version__ ${file_version}" >&2
-              exit 1
-            fi
           fi
 
           if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -178,6 +172,21 @@ jobs:
           ref: ${{ needs.version.outputs.tag }}
           # This job only builds; it never pushes. Do not leave a token in git.
           persist-credentials: false
+
+      # The release is tag-only (no version commit lands on main), so stamp the
+      # resolved version into the working tree before building. On a PR dry run
+      # version is empty and the repo's declared __version__ is used as-is.
+      - name: Stamp version
+        if: ${{ needs.version.outputs.version != '' }}
+        shell: bash
+        run: |
+          python - "src/petitepass/__init__.py" "${{ needs.version.outputs.version }}" <<'PY'
+          import re, sys
+          path, version = sys.argv[1], sys.argv[2]
+          text = open(path).read()
+          text = re.sub(r'__version__\s*=\s*"[^"]+"', f'__version__ = "{version}"', text)
+          open(path, "w").write(text)
+          PY
 
       - name: Set up Python
         uses: actions/setup-python@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,16 @@
 # - On every pull request, the OS matrix is built as a DRY RUN (no tag, no
 #   publish) so a packaging break is caught before merge.
 # - A release is cut manually via workflow_dispatch (choose a semver bump), or
-#   by pushing a v*.*.* tag. The dispatch path bumps src/petitepass/__init__.py,
-#   commits, and tags — so the tag, the package metadata, and `petitepass
-#   --version` all agree.
+#   by pushing a v*.*.* tag.
+#
+#   Git tags are the source of truth for release versions. main is protected
+#   (changes must go through a PR), so a release never commits to it: the
+#   dispatch path computes the next version from the latest v*.*.* tag and
+#   pushes ONLY that tag. The binary is version-stamped from the tag at build
+#   time, so `petitepass --version` and the published artifacts match the tag.
+#   The committed src/petitepass/__init__.py version is only the floor used for
+#   source installs between releases; bump it in a normal PR when you want
+#   `pip install .` to report a newer number.
 #
 # PyInstaller cannot cross-compile, so each OS is built on its own native
 # runner. The bundled common-password list is added via --add-data (the src:dest
@@ -21,7 +28,7 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Semver bump over the current version in src/petitepass/__init__.py"
+        description: "Semver bump over the latest vX.Y.Z release tag"
         type: choice
         options:
           - patch
@@ -47,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write   # commits the version bump and pushes the tag
+      contents: write   # pushes the release tag (never commits to main)
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       version: ${{ steps.resolve.outputs.version }}
@@ -173,9 +180,16 @@ jobs:
           # This job only builds; it never pushes. Do not leave a token in git.
           persist-credentials: false
 
-      # The release is tag-only (no version commit lands on main), so stamp the
-      # resolved version into the working tree before building. On a PR dry run
-      # version is empty and the repo's declared __version__ is used as-is.
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # Tags are the source of truth and no version commit lands on main, so
+      # stamp the resolved version into the working tree before freezing. Runs
+      # only on a real release (version is empty on the PR dry run). Fails closed:
+      # if the substitution does not land, the binary would freeze the wrong
+      # version while publish names the artifacts after the tag.
       - name: Stamp version
         if: ${{ needs.version.outputs.version != '' }}
         shell: bash
@@ -184,14 +198,11 @@ jobs:
           import re, sys
           path, version = sys.argv[1], sys.argv[2]
           text = open(path).read()
-          text = re.sub(r'__version__\s*=\s*"[^"]+"', f'__version__ = "{version}"', text)
-          open(path, "w").write(text)
+          new, n = re.subn(r'__version__\s*=\s*"[^"]+"', f'__version__ = "{version}"', text, count=1)
+          if n != 1:
+              sys.exit(f"failed to stamp __version__ in {path} (matched {n} times)")
+          open(path, "w").write(new)
           PY
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
 
       - name: Install dependencies
         run: |
@@ -223,9 +234,17 @@ jobs:
       - name: Verify binary (POSIX)
         if: ${{ matrix.os != 'windows' }}
         shell: bash
+        env:
+          EXPECT_VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
-          staging/petitepass --version
+          ver="$(staging/petitepass --version)"
+          echo "$ver"
+          # On a real release, the frozen binary MUST report the tag version.
+          if [ -n "$EXPECT_VERSION" ] && [ "$ver" != "petitepass ${EXPECT_VERSION}" ]; then
+            echo "version mismatch: expected 'petitepass ${EXPECT_VERSION}', got '$ver'" >&2
+            exit 1
+          fi
           out="$(staging/petitepass --selftest)"
           echo "$out"
           case "$out" in

--- a/src/petitepass/__init__.py
+++ b/src/petitepass/__init__.py
@@ -1,6 +1,8 @@
 """PetitePass — a lightweight, local, offline SQLCipher password manager."""
 
-# Single source of truth for the version. pyproject reads this via
-# `[tool.setuptools.dynamic]`, the release workflow bumps it, and
-# `petitepass --version` prints it.
+# Version floor for source installs. pyproject reads this via
+# `[tool.setuptools.dynamic]`, so `pip install .` reports it. Releases, however,
+# are cut as git tags: the release workflow stamps the tag's version into this
+# file at build time, so a published binary's `petitepass --version` matches its
+# tag even though this committed value is only bumped in a normal PR.
 __version__ = "2.0.5"


### PR DESCRIPTION
The first real `workflow_dispatch` release [failed](https://github.com/leo-aa88/PetitePass/actions/runs/33019553910/job/98346256364): the `version` job committed the bump and tried to push it to `main`, which the branch ruleset rejects — `GH013: Changes must be made through a pull request` (and required check `build`). It bumped `2.0.5 → 3.0.0` locally but couldn't push.

## Fix: make the release tag-only
- **`version` job** no longer writes `__init__.py` or pushes a commit to `main`. It computes the next version from the highest existing `v*.*.*` tag (falling back to `__init__.py` when there are none), creates the annotated tag, and **pushes only the tag**. Tags aren't covered by the branch-PR rule, and a tag pushed with `GITHUB_TOKEN` doesn't retrigger the workflow.
- **`build` job** stamps the resolved version into `src/petitepass/__init__.py` in the working tree before freezing, so `petitepass --version` and the artifact match the tag. On a PR dry run nothing is stamped.
- Dropped the tag-push file-match check (the file is no longer committed per release).

## Verified
- YAML valid; base-from-tag logic against the real tags: latest `v2.0.5` → `patch` `v2.0.6` / `minor` `v2.1.0` / `major` `v3.0.0` (matches the `major` dispatch that failed).

## Notes
- Because the bump isn't committed, `__version__` on `main` stays at its last committed value (2.0.5); **shipped binaries are stamped from the tag**. Bump `__version__` via a normal PR whenever you want source installs / `pip install .` to report the newer number.
- Remaining assumption: **tags are pushable** by the Actions bot (the ruleset that blocked us was branch-only). If you also have a *tag* ruleset requiring PRs, the tag push would fail and we'd need a PAT or a different trigger — but standard setups don't protect tags this way.

After this merges, re-run the release via **Actions → Release → Run workflow → bump: major** to cut `v3.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)